### PR TITLE
Updated Readme.md to include git client

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Like the other Docker projects, `swarm` follows the "batteries included but remo
 ### Installation
 
 ######1 - Download and install the current source code.
-Ensure you have golang installed (e.g. `apt-get install golang` on Ubuntu).
+Ensure you have golang and git client installed (e.g. `apt-get install golang git` on Ubuntu).
 You may need to set `$GOPATH`, e.g `mkdir ~/gocode; export GOPATH=~/gocode`.
 
 The install `swarm` binary to your `$GOPATH` directory.


### PR DESCRIPTION
`go get` command requires git client to be present in the system to work, so added the instruction to get git installed with golang package.
